### PR TITLE
Remove Vue slots depreciation rule from Eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "parserOptions": {
       "parser": "babel-eslint"
     },
-    "rules": {}
+    "rules": {
+      "vue/no-deprecated-slot-attribute": "off"
+    }
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
This PR will remove the "vue/no-deprecated-slot-attribute" error that comes when you try to use slots inside a webcomponent in Vue 3.